### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go vet ./...
+
+      - run: go test -race ./...
+
+      - uses: golangci/golangci-lint-action@v7


### PR DESCRIPTION
## Summary

Adds a CI pipeline that runs on every PR and push to main, plus Dependabot for automated dependency updates.

### CI workflow (`.github/workflows/ci.yml`)

Runs four checks in sequence:

1. **`go build ./...`** — compile all packages
2. **`go vet ./...`** — static analysis
3. **`go test -race ./...`** — full test suite with race detection
4. **`golangci-lint`** — linting via `golangci/golangci-lint-action@v7`

Uses `actions/setup-go@v5` with `go-version-file: go.mod` so the CI Go version stays in sync automatically. Built-in module and build caching — no separate cache action needed.

### Dependabot (`.github/dependabot.yml`)

Weekly updates for:
- Go modules (`gomod`)
- GitHub Actions versions (`github-actions`)

### After merge

Branch protection on main should be updated to require the CI status check. I'll do this once the workflow name is confirmed by the first run.

Closes #14