### PR TITLE
Add GoReleaser release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,31 @@
+version: 2
+
+builds:
+  - binary: lazybw
+    main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,3 +38,8 @@ tasks:
     desc: Format all Go source files
     cmds:
       - gofmt -l -w .
+
+  release-dry-run:
+    desc: Test GoReleaser config locally
+    cmds:
+      - goreleaser release --snapshot --clean

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-const version = "0.1.0-dev"
+var version = "dev"
 
 func main() {
 	debug := flag.Bool("debug", false, "write debug log to $XDG_CACHE_HOME/lazybw/debug.log")


### PR DESCRIPTION
## Summary

Adds automated release builds that produce cross-platform binaries when a version tag is pushed.

### What's included

**`.goreleaser.yml`** (GoReleaser v2)
- Builds static binaries (`CGO_ENABLED=0`) for Linux and macOS (amd64 + arm64)
- Version injected via `-ldflags "-X main.version={{.Version}}"` from the Git tag
- `tar.gz` archives with SHA256 checksums
- Auto-generated changelog filtered for noise (docs/test/ci commits excluded)

**`.github/workflows/release.yml`**
- Triggers on `v*` tag push (e.g. `git tag v0.1.0 && git push origin v0.1.0`)
- Full git history checkout for changelog generation
- Uses `goreleaser/goreleaser-action@v6` with GoReleaser v2
- Creates a GitHub Release with binaries attached

**`main.go`**
- Changed `const version = "0.1.0-dev"` to `var version = "dev"`
- Local builds show `dev`, tagged releases show the injected version

**`Taskfile.yml`**
- Added `release-dry-run` task for local GoReleaser testing

### Release targets

| OS | Arch | Archive |
|---|---|---|
| Linux | amd64 | `lazybw_X.Y.Z_linux_amd64.tar.gz` |
| Linux | arm64 | `lazybw_X.Y.Z_linux_arm64.tar.gz` |
| macOS | amd64 | `lazybw_X.Y.Z_darwin_amd64.tar.gz` |
| macOS | arm64 | `lazybw_X.Y.Z_darwin_arm64.tar.gz` |

### After merge

Tag `v0.1.0` to create the first release:
```sh
git tag v0.1.0
git push origin v0.1.0
```

Closes #15