### PR TITLE
Add Identity item type support

### DIFF
--- a/bwcmd/types.go
+++ b/bwcmd/types.go
@@ -47,6 +47,28 @@ type SecureNote struct {
 	Type int `json:"type"`
 }
 
+// Identity holds identity-specific fields.
+type Identity struct {
+	Title          string `json:"title"`
+	FirstName      string `json:"firstName"`
+	MiddleName     string `json:"middleName"`
+	LastName       string `json:"lastName"`
+	Username       string `json:"username"`
+	Company        string `json:"company"`
+	SSN            string `json:"ssn"`
+	PassportNumber string `json:"passportNumber"`
+	LicenseNumber  string `json:"licenseNumber"`
+	Email          string `json:"email"`
+	Phone          string `json:"phone"`
+	Address1       string `json:"address1"`
+	Address2       string `json:"address2"`
+	Address3       string `json:"address3"`
+	City           string `json:"city"`
+	State          string `json:"state"`
+	PostalCode     string `json:"postalCode"`
+	Country        string `json:"country"`
+}
+
 // Item is the top-level vault item returned by `bw list items`.
 type Item struct {
 	ID             string      `json:"id"`
@@ -58,6 +80,7 @@ type Item struct {
 	Login          *Login      `json:"login,omitempty"`
 	Card           *Card       `json:"card,omitempty"`
 	SecureNote     *SecureNote `json:"secureNote,omitempty"`
+	Identity       *Identity   `json:"identity,omitempty"`
 }
 
 // FilterValue implements bubbles/list.Item. Used for fuzzy filtering.
@@ -83,6 +106,16 @@ func (i Item) Description() string {
 			return first
 		}
 		return "(note)"
+	case ItemTypeIdentity:
+		if i.Identity != nil {
+			name := strings.TrimSpace(i.Identity.FirstName + " " + i.Identity.LastName)
+			if name != "" {
+				return name
+			}
+			if i.Identity.Email != "" {
+				return i.Identity.Email
+			}
+		}
 	}
 	return ""
 }

--- a/bwcmd/types_test.go
+++ b/bwcmd/types_test.go
@@ -44,6 +44,21 @@ func TestItemDescription(t *testing.T) {
 			want: "(note)",
 		},
 		{
+			name: "identity with name",
+			item: Item{Type: ItemTypeIdentity, Identity: &Identity{FirstName: "John", LastName: "Doe"}},
+			want: "John Doe",
+		},
+		{
+			name: "identity email fallback",
+			item: Item{Type: ItemTypeIdentity, Identity: &Identity{Email: "john@test.com"}},
+			want: "john@test.com",
+		},
+		{
+			name: "identity nil",
+			item: Item{Type: ItemTypeIdentity},
+			want: "",
+		},
+		{
 			name: "unknown type",
 			item: Item{Type: 99},
 			want: "",

--- a/screens/vault.go
+++ b/screens/vault.go
@@ -196,6 +196,9 @@ func (m VaultModel) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, m.keymap.Copy):
 		if item := m.selectedItem(); item != nil {
+			if item.Type == bwcmd.ItemTypeIdentity && item.Identity != nil && item.Identity.SSN != "" {
+				return m, session.CopyToClipboard(item.Identity.SSN, session.CopyFieldPassword)
+			}
 			return m, bwcmd.GetPassword(m.sess.Token, item.ID)
 		}
 
@@ -205,8 +208,13 @@ func (m VaultModel) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case key.Matches(msg, m.keymap.CopyUsername):
-		if item := m.selectedItem(); item != nil && item.Login != nil {
-			return m, session.CopyToClipboard(item.Login.Username, session.CopyFieldUsername)
+		if item := m.selectedItem(); item != nil {
+			if item.Login != nil {
+				return m, session.CopyToClipboard(item.Login.Username, session.CopyFieldUsername)
+			}
+			if item.Identity != nil && item.Identity.Email != "" {
+				return m, session.CopyToClipboard(item.Identity.Email, session.CopyFieldUsername)
+			}
 		}
 
 	case key.Matches(msg, m.keymap.OpenURL):

--- a/ui/drawer.go
+++ b/ui/drawer.go
@@ -35,6 +35,8 @@ func RenderDrawer(props DrawerProps) string {
 		fields = renderCardFields(props.Item)
 	case bwcmd.ItemTypeSecureNote:
 		fields = renderNoteFields(props)
+	case bwcmd.ItemTypeIdentity:
+		fields = renderIdentityFields(props.Item)
 	default:
 		fields = []string{StyleFaint.Render("  (unsupported item type)")}
 	}
@@ -172,6 +174,86 @@ func renderNoteFields(props DrawerProps) []string {
 		result[i] = "  " + line
 	}
 	return result
+}
+
+func renderIdentityFields(item *bwcmd.Item) []string {
+	if item.Identity == nil {
+		return []string{StyleFaint.Render("  (no identity data)")}
+	}
+	id := item.Identity
+	var fields []string
+
+	// Full name.
+	var parts []string
+	for _, p := range []string{id.Title, id.FirstName, id.MiddleName, id.LastName} {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		fields = append(fields, fieldRow("Name", strings.Join(parts, " "), ""))
+	}
+
+	if id.Email != "" {
+		fields = append(fields, fieldRow("Email", id.Email, "[u] copy"))
+	}
+	if id.Phone != "" {
+		fields = append(fields, fieldRow("Phone", id.Phone, ""))
+	}
+	if id.Company != "" {
+		fields = append(fields, fieldRow("Company", id.Company, ""))
+	}
+
+	// Sensitive fields — masked.
+	if id.SSN != "" {
+		fields = append(fields, fieldRow("SSN", "•••••••••", "[c] copy"))
+	}
+	if id.PassportNumber != "" {
+		fields = append(fields, fieldRow("Passport", "•••••••••", ""))
+	}
+	if id.LicenseNumber != "" {
+		fields = append(fields, fieldRow("License", "•••••••••", ""))
+	}
+
+	// Address.
+	addr := formatAddress(id)
+	if addr != "" {
+		fields = append(fields, fieldRow("Address", addr, ""))
+	}
+
+	if len(fields) == 0 {
+		fields = []string{StyleFaint.Render("  (empty identity)")}
+	}
+	return fields
+}
+
+func formatAddress(id *bwcmd.Identity) string {
+	var parts []string
+	for _, line := range []string{id.Address1, id.Address2, id.Address3} {
+		if line != "" {
+			parts = append(parts, line)
+		}
+	}
+	var cityState []string
+	if id.City != "" {
+		cityState = append(cityState, id.City)
+	}
+	if id.State != "" {
+		cityState = append(cityState, id.State)
+	}
+	if len(cityState) > 0 {
+		cs := strings.Join(cityState, ", ")
+		if id.PostalCode != "" {
+			cs += " " + id.PostalCode
+		}
+		parts = append(parts, cs)
+	} else if id.PostalCode != "" {
+		parts = append(parts, id.PostalCode)
+	}
+	if id.Country != "" {
+		parts = append(parts, id.Country)
+	}
+	return strings.Join(parts, ", ")
 }
 
 func fieldRow(label, value, hint string) string {

--- a/ui/drawer_test.go
+++ b/ui/drawer_test.go
@@ -155,6 +155,39 @@ func TestRenderDrawerTOTPLoading(t *testing.T) {
 	}
 }
 
+func TestRenderDrawerIdentity(t *testing.T) {
+	item := &bwcmd.Item{
+		Type: bwcmd.ItemTypeIdentity,
+		Name: "Personal",
+		Identity: &bwcmd.Identity{
+			FirstName: "John",
+			LastName:  "Doe",
+			Email:     "john@test.com",
+			Phone:     "+1-555-0123",
+			SSN:       "123-45-6789",
+			City:      "Springfield",
+			State:     "IL",
+		},
+	}
+	out := RenderDrawer(DrawerProps{Item: item, Width: 80})
+	if !strings.Contains(out, "Name") {
+		t.Error("identity drawer should contain 'Name'")
+	}
+	if !strings.Contains(out, "Email") {
+		t.Error("identity drawer should contain 'Email'")
+	}
+	if !strings.Contains(out, "Identity") {
+		t.Error("separator should contain 'Identity'")
+	}
+	if !strings.Contains(out, "•••••••••") {
+		t.Error("SSN should be masked")
+	}
+	if strings.Contains(out, "123-45-6789") {
+		t.Error("SSN value should NOT appear in output")
+	}
+	assertMinLineCount(t, out, DrawerHeight-1)
+}
+
 func assertMinLineCount(t *testing.T, output string, minExpected int) {
 	t.Helper()
 	// Count newline-separated segments. Trailing empty lines from padding

--- a/ui/itemrow.go
+++ b/ui/itemrow.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	glyphLogin = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰌾")
-	glyphCard  = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰁯")
-	glyphNote  = lipgloss.NewStyle().Foreground(ColorYellow).Render("󱙒")
+	glyphLogin    = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰌾")
+	glyphCard     = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰁯")
+	glyphNote     = lipgloss.NewStyle().Foreground(ColorYellow).Render("󱙒")
+	glyphIdentity = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰀄")
 )
 
 // RenderItemRow renders a single item row in the vault list.
@@ -29,6 +30,8 @@ func RenderItemRow(item bwcmd.Item, selected bool, width int) string {
 		glyph = glyphCard
 	case bwcmd.ItemTypeSecureNote:
 		glyph = glyphNote
+	case bwcmd.ItemTypeIdentity:
+		glyph = glyphIdentity
 	default:
 		glyph = " "
 	}

--- a/ui/itemrow_test.go
+++ b/ui/itemrow_test.go
@@ -67,6 +67,21 @@ func TestRenderItemRowNote(t *testing.T) {
 	}
 }
 
+func TestRenderItemRowIdentity(t *testing.T) {
+	item := bwcmd.Item{
+		Type:     bwcmd.ItemTypeIdentity,
+		Name:     "Personal ID",
+		Identity: &bwcmd.Identity{FirstName: "John", LastName: "Doe"},
+	}
+	out := RenderItemRow(item, false, 60)
+	if !strings.Contains(out, "Personal ID") {
+		t.Error("row should contain identity name")
+	}
+	if !strings.Contains(out, "John Doe") {
+		t.Error("row should contain full name as description")
+	}
+}
+
 func TestRenderItemRowTruncation(t *testing.T) {
 	item := bwcmd.Item{
 		Type: bwcmd.ItemTypeLogin,


### PR DESCRIPTION
## Summary

Adds full read-only support for Bitwarden Identity items (type 4) in the vault view.

### Changes

**Data model** (`bwcmd/types.go`)
- Added `Identity` struct with 18 fields: name (title, first, middle, last), contact (email, phone, username, company), identification (SSN, passport, license number), and address (address1-3, city, state, postal code, country)
- Added `Identity *Identity` to `Item` with JSON mapping
- `Description()` returns full name ("John Doe") with email as fallback

**Item row** (`ui/itemrow.go`)
- Added `󰀄` (nf-md-account) glyph in purple for identity items

**Drawer** (`ui/drawer.go`)
- Added `renderIdentityFields()` with logical grouping:
  - Name (title + first + middle + last)
  - Email `[u] copy`, Phone, Company
  - SSN `[c] copy`, Passport, License — all masked (`•••••••••`)
  - Address (formatted single line)
- Only non-empty fields shown

**Copy keybindings** (`screens/vault.go`)
- `c` on identity item → copies SSN (primary sensitive field)
- `u` on identity item → copies email

**Tests**
- `types_test.go` — identity with name, email fallback, nil identity
- `drawer_test.go` — identity fields rendered, SSN masked (value not leaked)
- `itemrow_test.go` — identity row with glyph and description

### Drawer preview

```
── Personal ──────────────────────────────── Identity ─
  Name        Mr. John Q. Doe
  Email       john@example.com              [u] copy
  Phone       +1-555-0123
  Company     Acme Corp
  SSN         •••••••••                     [c] copy
  Address     123 Main St, Springfield, IL 62701
```

Closes #4