### PR TITLE
Add SSH Key item type support

### DIFF
--- a/bwcmd/types.go
+++ b/bwcmd/types.go
@@ -17,6 +17,7 @@ const (
 	ItemTypeSecureNote ItemType = 2
 	ItemTypeCard       ItemType = 3
 	ItemTypeIdentity   ItemType = 4
+	ItemTypeSSHKey     ItemType = 5
 )
 
 // URI represents a single URL entry on a Login item.
@@ -69,6 +70,13 @@ type Identity struct {
 	Country        string `json:"country"`
 }
 
+// SSHKey holds SSH key-specific fields.
+type SSHKey struct {
+	PrivateKey     string `json:"privateKey"`
+	PublicKey      string `json:"publicKey"`
+	KeyFingerprint string `json:"keyFingerprint"`
+}
+
 // Item is the top-level vault item returned by `bw list items`.
 type Item struct {
 	ID             string      `json:"id"`
@@ -81,6 +89,7 @@ type Item struct {
 	Card           *Card       `json:"card,omitempty"`
 	SecureNote     *SecureNote `json:"secureNote,omitempty"`
 	Identity       *Identity   `json:"identity,omitempty"`
+	SSHKey         *SSHKey     `json:"sshKey,omitempty"`
 }
 
 // FilterValue implements bubbles/list.Item. Used for fuzzy filtering.
@@ -115,6 +124,10 @@ func (i Item) Description() string {
 			if i.Identity.Email != "" {
 				return i.Identity.Email
 			}
+		}
+	case ItemTypeSSHKey:
+		if i.SSHKey != nil && i.SSHKey.KeyFingerprint != "" {
+			return i.SSHKey.KeyFingerprint
 		}
 	}
 	return ""

--- a/bwcmd/types_test.go
+++ b/bwcmd/types_test.go
@@ -59,6 +59,16 @@ func TestItemDescription(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "ssh key with fingerprint",
+			item: Item{Type: ItemTypeSSHKey, SSHKey: &SSHKey{KeyFingerprint: "SHA256:abc123"}},
+			want: "SHA256:abc123",
+		},
+		{
+			name: "ssh key nil",
+			item: Item{Type: ItemTypeSSHKey},
+			want: "",
+		},
+		{
 			name: "unknown type",
 			item: Item{Type: 99},
 			want: "",

--- a/screens/vault.go
+++ b/screens/vault.go
@@ -199,6 +199,9 @@ func (m VaultModel) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if item.Type == bwcmd.ItemTypeIdentity && item.Identity != nil && item.Identity.SSN != "" {
 				return m, session.CopyToClipboard(item.Identity.SSN, session.CopyFieldPassword)
 			}
+			if item.Type == bwcmd.ItemTypeSSHKey && item.SSHKey != nil && item.SSHKey.PrivateKey != "" {
+				return m, session.CopyToClipboard(item.SSHKey.PrivateKey, session.CopyFieldPassword)
+			}
 			return m, bwcmd.GetPassword(m.sess.Token, item.ID)
 		}
 
@@ -214,6 +217,9 @@ func (m VaultModel) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			if item.Identity != nil && item.Identity.Email != "" {
 				return m, session.CopyToClipboard(item.Identity.Email, session.CopyFieldUsername)
+			}
+			if item.SSHKey != nil && item.SSHKey.PublicKey != "" {
+				return m, session.CopyToClipboard(item.SSHKey.PublicKey, session.CopyFieldUsername)
 			}
 		}
 

--- a/ui/drawer.go
+++ b/ui/drawer.go
@@ -37,6 +37,8 @@ func RenderDrawer(props DrawerProps) string {
 		fields = renderNoteFields(props)
 	case bwcmd.ItemTypeIdentity:
 		fields = renderIdentityFields(props.Item)
+	case bwcmd.ItemTypeSSHKey:
+		fields = renderSSHKeyFields(props.Item)
 	default:
 		fields = []string{StyleFaint.Render("  (unsupported item type)")}
 	}
@@ -83,6 +85,8 @@ func itemTypeName(t bwcmd.ItemType) string {
 		return "Card"
 	case bwcmd.ItemTypeIdentity:
 		return "Identity"
+	case bwcmd.ItemTypeSSHKey:
+		return "SSH Key"
 	default:
 		return "Item"
 	}
@@ -254,6 +258,33 @@ func formatAddress(id *bwcmd.Identity) string {
 		parts = append(parts, id.Country)
 	}
 	return strings.Join(parts, ", ")
+}
+
+func renderSSHKeyFields(item *bwcmd.Item) []string {
+	if item.SSHKey == nil {
+		return []string{StyleFaint.Render("  (no SSH key data)")}
+	}
+	k := item.SSHKey
+	var fields []string
+
+	if k.KeyFingerprint != "" {
+		fields = append(fields, fieldRow("Fingerprint", k.KeyFingerprint, ""))
+	}
+
+	if k.PublicKey != "" {
+		display := k.PublicKey
+		if len(display) > 40 {
+			display = display[:40] + "…"
+		}
+		fields = append(fields, fieldRow("Public Key", display, "[u] copy"))
+	}
+
+	fields = append(fields, fieldRow("Private Key", "••••••••••", "[c] copy"))
+
+	if len(fields) == 0 {
+		fields = []string{StyleFaint.Render("  (empty SSH key)")}
+	}
+	return fields
 }
 
 func fieldRow(label, value, hint string) string {

--- a/ui/drawer_test.go
+++ b/ui/drawer_test.go
@@ -188,6 +188,38 @@ func TestRenderDrawerIdentity(t *testing.T) {
 	assertMinLineCount(t, out, DrawerHeight-1)
 }
 
+func TestRenderDrawerSSHKey(t *testing.T) {
+	item := &bwcmd.Item{
+		Type: bwcmd.ItemTypeSSHKey,
+		Name: "Server Key",
+		SSHKey: &bwcmd.SSHKey{
+			KeyFingerprint: "SHA256:abc123def456",
+			PublicKey:      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...",
+			PrivateKey:     "-----BEGIN OPENSSH PRIVATE KEY-----\nb3Blbn...",
+		},
+	}
+	out := RenderDrawer(DrawerProps{Item: item, Width: 80})
+	if !strings.Contains(out, "Fingerprint") {
+		t.Error("SSH key drawer should contain 'Fingerprint'")
+	}
+	if !strings.Contains(out, "Public Key") {
+		t.Error("SSH key drawer should contain 'Public Key'")
+	}
+	if !strings.Contains(out, "Private Key") {
+		t.Error("SSH key drawer should contain 'Private Key'")
+	}
+	if !strings.Contains(out, "SSH Key") {
+		t.Error("separator should contain 'SSH Key'")
+	}
+	if strings.Contains(out, "BEGIN OPENSSH") {
+		t.Error("private key value should NOT appear in output")
+	}
+	if !strings.Contains(out, "••••••••••") {
+		t.Error("private key should be masked")
+	}
+	assertMinLineCount(t, out, DrawerHeight-1)
+}
+
 func assertMinLineCount(t *testing.T, output string, minExpected int) {
 	t.Helper()
 	// Count newline-separated segments. Trailing empty lines from padding

--- a/ui/itemrow.go
+++ b/ui/itemrow.go
@@ -13,6 +13,7 @@ var (
 	glyphCard     = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰁯")
 	glyphNote     = lipgloss.NewStyle().Foreground(ColorYellow).Render("󱙒")
 	glyphIdentity = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰀄")
+	glyphSSHKey   = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰣀")
 )
 
 // RenderItemRow renders a single item row in the vault list.
@@ -32,6 +33,8 @@ func RenderItemRow(item bwcmd.Item, selected bool, width int) string {
 		glyph = glyphNote
 	case bwcmd.ItemTypeIdentity:
 		glyph = glyphIdentity
+	case bwcmd.ItemTypeSSHKey:
+		glyph = glyphSSHKey
 	default:
 		glyph = " "
 	}

--- a/ui/itemrow_test.go
+++ b/ui/itemrow_test.go
@@ -82,6 +82,21 @@ func TestRenderItemRowIdentity(t *testing.T) {
 	}
 }
 
+func TestRenderItemRowSSHKey(t *testing.T) {
+	item := bwcmd.Item{
+		Type:   bwcmd.ItemTypeSSHKey,
+		Name:   "Server Key",
+		SSHKey: &bwcmd.SSHKey{KeyFingerprint: "SHA256:abc123"},
+	}
+	out := RenderItemRow(item, false, 60)
+	if !strings.Contains(out, "Server Key") {
+		t.Error("row should contain SSH key name")
+	}
+	if !strings.Contains(out, "SHA256:abc123") {
+		t.Error("row should contain fingerprint as description")
+	}
+}
+
 func TestRenderItemRowTruncation(t *testing.T) {
 	item := bwcmd.Item{
 		Type: bwcmd.ItemTypeLogin,


### PR DESCRIPTION
## Summary

Adds full read-only support for Bitwarden SSH Key items (type 5) in the vault view.

### Changes

**Data model** (`bwcmd/types.go`)
- Added `ItemTypeSSHKey = 5` constant
- Added `SSHKey` struct with `privateKey`, `publicKey`, `keyFingerprint` JSON fields
- Added `SSHKey *SSHKey` to `Item`
- `Description()` returns key fingerprint

**Item row** (`ui/itemrow.go`)
- Added `󰣀` (nf-md-key_chain) glyph in green for SSH key items

**Drawer** (`ui/drawer.go`)
- Added `renderSSHKeyFields()` showing:
  - Fingerprint (visible)
  - Public key (truncated to 40 chars, `[u] copy`)
  - Private key (always masked `••••••••••`, `[c] copy`)
- Added "SSH Key" to `itemTypeName()`

**Copy keybindings** (`screens/vault.go`)
- `c` on SSH key item → copies private key
- `u` on SSH key item → copies public key

**Tests**
- `types_test.go` — SSH key with fingerprint, nil SSH key
- `drawer_test.go` — fields rendered, private key masked (value not leaked)
- `itemrow_test.go` — SSH key row with name and fingerprint

### Drawer preview

```
── Server Key ────────────────────────────── SSH Key ─
  Fingerprint  SHA256:abc123def456...
  Public Key   ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AA…   [u] copy
  Private Key  ••••••••••                             [c] copy
```

Closes #5