### PR TITLE
Add Catppuccin/Charm theme support with live picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,17 @@ On first launch, lazybw checks `bw status` and prompts you to log in or unlock a
 | Flag | Default | Description |
 |---|---|---|
 | `--idle-timeout` | `15m` | Lock the vault after this duration of inactivity |
+| `--theme` | `catppuccin-mocha` | Color theme (see below) |
 | `--debug` | `false` | Write debug log to `$XDG_CACHE_HOME/lazybw/debug.log` |
 | `--version` | | Print version and exit |
+
+You can also set the theme via the `LAZYBW_THEME` environment variable (flag takes precedence).
+
+### Themes
+
+Available themes: `catppuccin-mocha` (default), `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-latte`, `dracula`, `charm`, `base16`.
+
+Press `T` in the vault to open the theme picker and switch themes on the fly.
 
 ### Keybindings
 
@@ -101,6 +110,7 @@ On first launch, lazybw checks `bw status` and prompts you to log in or unlock a
 | `J` / `K` | Scroll note content in drawer |
 | `Ctrl+r` | Sync vault |
 | `Ctrl+l` | Lock vault |
+| `T` | Open theme picker |
 | `?` | Toggle full help |
 | `q` | Lock and quit |
 

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,16 @@ go 1.24.0
 
 require (
 	github.com/atotto/clipboard v0.1.4
+	github.com/catppuccin/go v0.3.0
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/muesli/termenv v0.16.0
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
@@ -27,7 +28,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
-github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
+github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
+github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
 github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.3.5 h1:JAMNLTbqMOhSwoELIr0qyP4VidFq72/6E9j7HHmRKQc=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/juthrbog/lazybw/ui"
 )
 
 var version = "dev"
@@ -18,11 +19,21 @@ func main() {
 	debug := flag.Bool("debug", false, "write debug log to $XDG_CACHE_HOME/lazybw/debug.log")
 	ver := flag.Bool("version", false, "print version and exit")
 	idleTimeout := flag.Duration("idle-timeout", 15*time.Minute, "lock vault after this duration of inactivity")
+	theme := flag.String("theme", "", "color theme (catppuccin-mocha, catppuccin-frappe, catppuccin-macchiato, catppuccin-latte, dracula, charm, base16)")
 	flag.Parse()
 
 	if *ver {
 		fmt.Println("lazybw", version)
 		return
+	}
+
+	// Apply theme: flag > env var > default (catppuccin-mocha).
+	themeName := *theme
+	if themeName == "" {
+		themeName = os.Getenv("LAZYBW_THEME")
+	}
+	if themeName != "" {
+		ui.ApplyTheme(themeName)
 	}
 
 	if _, err := exec.LookPath("bw"); err != nil {

--- a/screens/locked.go
+++ b/screens/locked.go
@@ -59,14 +59,20 @@ func buildLockedForm(isLogin bool, email, password *string) *huh.Form {
 		EchoMode(huh.EchoModePassword).
 		Value(password)
 
+	var form *huh.Form
 	if isLogin {
 		emailField := huh.NewInput().
 			Key("email").
 			Title("Email").
 			Value(email)
-		return huh.NewForm(huh.NewGroup(emailField, pwField))
+		form = huh.NewForm(huh.NewGroup(emailField, pwField))
+	} else {
+		form = huh.NewForm(huh.NewGroup(pwField))
 	}
-	return huh.NewForm(huh.NewGroup(pwField))
+	if ui.HuhTheme != nil {
+		form = form.WithTheme(ui.HuhTheme)
+	}
+	return form
 }
 
 func (m LockedModel) Init() tea.Cmd {

--- a/screens/vault.go
+++ b/screens/vault.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/juthrbog/lazybw/bwcmd"
 	"github.com/juthrbog/lazybw/session"
@@ -52,6 +53,11 @@ type VaultModel struct {
 
 	drawerScroll int
 
+	currentTheme    string
+	showThemePicker bool
+	themeForm       *huh.Form
+	selectedTheme   string
+
 	width  int
 	height int
 }
@@ -67,8 +73,9 @@ func NewVaultModel(items []bwcmd.Item, sess *session.State, width, height int) V
 		keymap:      ui.DefaultVaultKeyMap(),
 		help:        help.New(),
 		sess:        sess,
-		syncSpinner: ss,
-		width:       width,
+		syncSpinner:  ss,
+		currentTheme: ui.CurrentTheme,
+		width:        width,
 		height:      height,
 	}
 	return m
@@ -90,6 +97,9 @@ func (m VaultModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 
 	case tea.KeyMsg:
+		if m.showThemePicker {
+			return m.updateThemePicker(msg)
+		}
 		if m.mode == modeFilter {
 			return m.updateFilter(msg)
 		}
@@ -247,6 +257,9 @@ func (m VaultModel) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showHelp = !m.showHelp
 		return m, nil
 
+	case key.Matches(msg, m.keymap.CycleTheme):
+		return m.openThemePicker()
+
 	case key.Matches(msg, m.keymap.Quit):
 		return m, func() tea.Msg { return LockMsg{} }
 
@@ -353,8 +366,54 @@ func (m *VaultModel) setToast(msg string) {
 	m.toastTime = time.Now()
 }
 
+func (m VaultModel) openThemePicker() (tea.Model, tea.Cmd) {
+	m.selectedTheme = m.currentTheme
+	options := make([]huh.Option[string], len(ui.ThemeNames))
+	for i, name := range ui.ThemeNames {
+		options[i] = huh.NewOption(name, name)
+	}
+	m.themeForm = huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Choose theme").
+				Options(options...).
+				Value(&m.selectedTheme),
+		),
+	)
+	if ui.HuhTheme != nil {
+		m.themeForm = m.themeForm.WithTheme(ui.HuhTheme)
+	}
+	m.showThemePicker = true
+	return m, m.themeForm.Init()
+}
+
+func (m VaultModel) updateThemePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	form, cmd := m.themeForm.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		m.themeForm = f
+	}
+
+	switch m.themeForm.State {
+	case huh.StateCompleted:
+		m.showThemePicker = false
+		ui.ApplyTheme(m.selectedTheme)
+		m.currentTheme = m.selectedTheme
+		m.setToast("Theme: " + m.selectedTheme)
+		return m, nil
+	case huh.StateAborted:
+		m.showThemePicker = false
+		return m, nil
+	}
+
+	return m, cmd
+}
+
 // ViewContent renders the vault content for the root frame.
 func (m VaultModel) ViewContent(width, contentHeight int) string {
+	if m.showThemePicker && m.themeForm != nil {
+		return ui.CenterInArea(m.themeForm.View(), width, contentHeight)
+	}
+
 	drawer := ui.RenderDrawer(ui.DrawerProps{
 		Item:         m.selectedItem(),
 		TOTPCode:     m.totpCode,
@@ -391,10 +450,14 @@ func (m VaultModel) ViewContent(width, contentHeight int) string {
 
 // FooterContent returns hints and status for the footer bar.
 func (m VaultModel) FooterContent() (hints, status string) {
+	if m.showThemePicker {
+		hints = "enter select · esc cancel"
+		return hints, ""
+	}
 	if m.mode == modeFilter {
 		hints = "esc clear · enter confirm · ↑/↓ navigate"
 	} else {
-		hints = "j/k navigate · / search · c pwd · t totp · ? help · q quit"
+		hints = "j/k navigate · / search · c pwd · t totp · T theme · ? help · q quit"
 	}
 
 	toast := m.toast

--- a/ui/itemrow.go
+++ b/ui/itemrow.go
@@ -8,14 +8,6 @@ import (
 	"github.com/juthrbog/lazybw/bwcmd"
 )
 
-var (
-	glyphLogin    = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰌾")
-	glyphCard     = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰁯")
-	glyphNote     = lipgloss.NewStyle().Foreground(ColorYellow).Render("󱙒")
-	glyphIdentity = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰀄")
-	glyphSSHKey   = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰣀")
-)
-
 // RenderItemRow renders a single item row in the vault list.
 func RenderItemRow(item bwcmd.Item, selected bool, width int) string {
 	cursor := "  "
@@ -26,15 +18,15 @@ func RenderItemRow(item bwcmd.Item, selected bool, width int) string {
 	var glyph string
 	switch item.Type {
 	case bwcmd.ItemTypeLogin:
-		glyph = glyphLogin
+		glyph = GlyphLogin
 	case bwcmd.ItemTypeCard:
-		glyph = glyphCard
+		glyph = GlyphCard
 	case bwcmd.ItemTypeSecureNote:
-		glyph = glyphNote
+		glyph = GlyphNote
 	case bwcmd.ItemTypeIdentity:
-		glyph = glyphIdentity
+		glyph = GlyphIdentity
 	case bwcmd.ItemTypeSSHKey:
-		glyph = glyphSSHKey
+		glyph = GlyphSSHKey
 	default:
 		glyph = " "
 	}

--- a/ui/keymap.go
+++ b/ui/keymap.go
@@ -19,6 +19,7 @@ type VaultKeyMap struct {
 	Lock         key.Binding
 	Help         key.Binding
 	Quit         key.Binding
+	CycleTheme   key.Binding
 }
 
 // ShortHelp implements help.KeyMap.
@@ -33,7 +34,7 @@ func (k VaultKeyMap) FullHelp() [][]key.Binding {
 		{k.Copy, k.CopyTOTP, k.CopyUsername, k.OpenURL},
 		{k.Filter, k.Sync, k.Lock},
 		{k.ScrollDown, k.ScrollUp},
-		{k.Help, k.Quit},
+		{k.Help, k.CycleTheme, k.Quit},
 	}
 }
 
@@ -99,6 +100,10 @@ func DefaultVaultKeyMap() VaultKeyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
 			key.WithHelp("q", "quit"),
+		),
+		CycleTheme: key.NewBinding(
+			key.WithKeys("T"),
+			key.WithHelp("T", "theme"),
 		),
 	}
 }

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -4,17 +4,34 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+
+	catppuccin "github.com/catppuccin/go"
 )
 
-// Colour palette — AdaptiveColor adapts to dark/light terminal backgrounds.
+// ThemeNames lists all available themes.
+var ThemeNames = []string{
+	"catppuccin-mocha",
+	"catppuccin-frappe",
+	"catppuccin-macchiato",
+	"catppuccin-latte",
+	"dracula",
+	"charm",
+	"base16",
+}
+
+// CurrentTheme holds the name of the active theme.
+var CurrentTheme = "catppuccin-mocha"
+
+// Colour palette — set by ApplyTheme.
 var (
-	ColorHighlight = lipgloss.AdaptiveColor{Dark: "#7D56F4", Light: "#5A3ECC"} // login glyph, selected
-	ColorSubtle    = lipgloss.AdaptiveColor{Dark: "#383838", Light: "#D9DCCF"} // separator lines, bg
-	ColorGreen     = lipgloss.AdaptiveColor{Dark: "#04B575", Light: "#027A4F"} // card glyph, copy toast, TOTP ok
-	ColorYellow    = lipgloss.AdaptiveColor{Dark: "#F5A623", Light: "#C47D10"} // note glyph, TOTP warning
-	ColorRed       = lipgloss.AdaptiveColor{Dark: "#FF4F4F", Light: "#CC2222"} // errors, TOTP urgent
-	ColorFaint     = lipgloss.AdaptiveColor{Dark: "#626262", Light: "#9A9A9A"} // descriptions, secondary text
+	ColorHighlight lipgloss.AdaptiveColor
+	ColorSubtle    lipgloss.AdaptiveColor
+	ColorGreen     lipgloss.AdaptiveColor
+	ColorYellow    lipgloss.AdaptiveColor
+	ColorRed       lipgloss.AdaptiveColor
+	ColorFaint     lipgloss.AdaptiveColor
 )
 
 // Spinner definitions for loading states.
@@ -30,7 +47,7 @@ var (
 	SpinnerLoad = spinner.Dot
 )
 
-// Pre-built styles initialised once at package load.
+// Pre-built styles — set by initStyles, called from ApplyTheme.
 var (
 	StyleTitle     lipgloss.Style
 	StyleSelected  lipgloss.Style
@@ -41,7 +58,93 @@ var (
 	StyleError     lipgloss.Style
 )
 
+// HuhTheme is applied to huh forms (unlock/login screen).
+var HuhTheme *huh.Theme
+
+// Glyph variables — re-rendered by initStyles after theme change.
+var (
+	GlyphLogin    string
+	GlyphCard     string
+	GlyphNote     string
+	GlyphIdentity string
+	GlyphSSHKey   string
+)
+
 func init() {
+	ApplyTheme("catppuccin-mocha")
+}
+
+// ApplyTheme sets the color palette, styles, and glyphs for the given theme.
+func ApplyTheme(name string) {
+	CurrentTheme = name
+
+	switch name {
+	case "catppuccin-mocha":
+		applyCatppuccin(catppuccin.Mocha, catppuccin.Latte)
+		HuhTheme = huh.ThemeCatppuccin()
+	case "catppuccin-frappe":
+		applyCatppuccin(catppuccin.Frappe, catppuccin.Latte)
+		HuhTheme = huh.ThemeCatppuccin()
+	case "catppuccin-macchiato":
+		applyCatppuccin(catppuccin.Macchiato, catppuccin.Latte)
+		HuhTheme = huh.ThemeCatppuccin()
+	case "catppuccin-latte":
+		applyCatppuccin(catppuccin.Latte, catppuccin.Latte)
+		HuhTheme = huh.ThemeCatppuccin()
+	case "dracula":
+		applyDracula()
+		HuhTheme = huh.ThemeDracula()
+	case "charm":
+		applyCharm()
+		HuhTheme = huh.ThemeCharm()
+	case "base16":
+		applyBase16()
+		HuhTheme = huh.ThemeBase16()
+	default:
+		applyCatppuccin(catppuccin.Mocha, catppuccin.Latte)
+		HuhTheme = huh.ThemeCatppuccin()
+	}
+
+	initStyles()
+}
+
+func applyCatppuccin(dark, light catppuccin.Flavor) {
+	ColorHighlight = lipgloss.AdaptiveColor{Dark: dark.Mauve().Hex, Light: light.Mauve().Hex}
+	ColorSubtle = lipgloss.AdaptiveColor{Dark: dark.Surface0().Hex, Light: light.Surface0().Hex}
+	ColorGreen = lipgloss.AdaptiveColor{Dark: dark.Green().Hex, Light: light.Green().Hex}
+	ColorYellow = lipgloss.AdaptiveColor{Dark: dark.Yellow().Hex, Light: light.Yellow().Hex}
+	ColorRed = lipgloss.AdaptiveColor{Dark: dark.Red().Hex, Light: light.Red().Hex}
+	ColorFaint = lipgloss.AdaptiveColor{Dark: dark.Overlay0().Hex, Light: light.Overlay0().Hex}
+}
+
+func applyDracula() {
+	ColorHighlight = lipgloss.AdaptiveColor{Dark: "#bd93f9", Light: "#7c3aed"}
+	ColorSubtle = lipgloss.AdaptiveColor{Dark: "#44475a", Light: "#D9DCCF"}
+	ColorGreen = lipgloss.AdaptiveColor{Dark: "#50fa7b", Light: "#027A4F"}
+	ColorYellow = lipgloss.AdaptiveColor{Dark: "#f1fa8c", Light: "#C47D10"}
+	ColorRed = lipgloss.AdaptiveColor{Dark: "#ff5555", Light: "#CC2222"}
+	ColorFaint = lipgloss.AdaptiveColor{Dark: "#6272a4", Light: "#9A9A9A"}
+}
+
+func applyCharm() {
+	ColorHighlight = lipgloss.AdaptiveColor{Dark: "#7D56F4", Light: "#5A3ECC"}
+	ColorSubtle = lipgloss.AdaptiveColor{Dark: "#383838", Light: "#D9DCCF"}
+	ColorGreen = lipgloss.AdaptiveColor{Dark: "#04B575", Light: "#027A4F"}
+	ColorYellow = lipgloss.AdaptiveColor{Dark: "#F5A623", Light: "#C47D10"}
+	ColorRed = lipgloss.AdaptiveColor{Dark: "#FF4F4F", Light: "#CC2222"}
+	ColorFaint = lipgloss.AdaptiveColor{Dark: "#626262", Light: "#9A9A9A"}
+}
+
+func applyBase16() {
+	ColorHighlight = lipgloss.AdaptiveColor{Dark: "#a16946", Light: "#a16946"}
+	ColorSubtle = lipgloss.AdaptiveColor{Dark: "#383838", Light: "#D9DCCF"}
+	ColorGreen = lipgloss.AdaptiveColor{Dark: "#a1b56c", Light: "#027A4F"}
+	ColorYellow = lipgloss.AdaptiveColor{Dark: "#f7ca88", Light: "#C47D10"}
+	ColorRed = lipgloss.AdaptiveColor{Dark: "#ab4642", Light: "#CC2222"}
+	ColorFaint = lipgloss.AdaptiveColor{Dark: "#585858", Light: "#9A9A9A"}
+}
+
+func initStyles() {
 	StyleTitle = lipgloss.NewStyle().
 		Bold(true).
 		Foreground(ColorHighlight)
@@ -67,4 +170,11 @@ func init() {
 	StyleError = lipgloss.NewStyle().
 		Foreground(ColorRed).
 		Bold(true)
+
+	// Re-render glyphs with new colors.
+	GlyphLogin = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰌾")
+	GlyphCard = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰁯")
+	GlyphNote = lipgloss.NewStyle().Foreground(ColorYellow).Render("󱙒")
+	GlyphIdentity = lipgloss.NewStyle().Foreground(ColorHighlight).Render("󰀄")
+	GlyphSSHKey = lipgloss.NewStyle().Foreground(ColorGreen).Render("󰣀")
 }

--- a/ui/theme_test.go
+++ b/ui/theme_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import "testing"
+
+func TestApplyThemeCatppuccinMocha(t *testing.T) {
+	ApplyTheme("catppuccin-mocha")
+	if CurrentTheme != "catppuccin-mocha" {
+		t.Errorf("CurrentTheme = %q, want %q", CurrentTheme, "catppuccin-mocha")
+	}
+	// Mocha mauve is #cba6f7.
+	if ColorHighlight.Dark != "#cba6f7" {
+		t.Errorf("Mocha highlight dark = %q, want #cba6f7", ColorHighlight.Dark)
+	}
+	if HuhTheme == nil {
+		t.Error("HuhTheme should not be nil")
+	}
+}
+
+func TestApplyThemeDracula(t *testing.T) {
+	ApplyTheme("dracula")
+	if CurrentTheme != "dracula" {
+		t.Errorf("CurrentTheme = %q, want %q", CurrentTheme, "dracula")
+	}
+	if ColorHighlight.Dark != "#bd93f9" {
+		t.Errorf("Dracula highlight dark = %q, want #bd93f9", ColorHighlight.Dark)
+	}
+}
+
+func TestApplyThemeUpdatesGlyphs(t *testing.T) {
+	ApplyTheme("catppuccin-mocha")
+	if GlyphLogin == "" {
+		t.Error("GlyphLogin should not be empty after ApplyTheme")
+	}
+	if GlyphCard == "" {
+		t.Error("GlyphCard should not be empty after ApplyTheme")
+	}
+}
+
+func TestApplyThemeUnknownFallsToDefault(t *testing.T) {
+	ApplyTheme("nonexistent")
+	// Should fall through to catppuccin-mocha colors.
+	if ColorHighlight.Dark != "#cba6f7" {
+		t.Errorf("fallback highlight dark = %q, want #cba6f7", ColorHighlight.Dark)
+	}
+}
+
+func TestThemeNamesNotEmpty(t *testing.T) {
+	if len(ThemeNames) == 0 {
+		t.Error("ThemeNames should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded color palette with theme-aware colors sourced from the Catppuccin palette via `catppuccin/go`. Adds 7 selectable themes with three ways to choose: CLI flag, env var, or an in-app theme picker.

### Available themes

| Theme | Description |
|---|---|
| `catppuccin-mocha` (default) | Dark, warm tones |
| `catppuccin-frappe` | Dark, subdued |
| `catppuccin-macchiato` | Dark, medium contrast |
| `catppuccin-latte` | Light |
| `dracula` | Classic Dracula colors |
| `charm` | Original lazybw palette |
| `base16` | Base16 default dark |

### How to select

- **Flag**: `lazybw --theme catppuccin-frappe`
- **Env var**: `LAZYBW_THEME=dracula lazybw` (flag takes precedence)
- **Live picker**: Press `T` in the vault — opens a `huh.Select` picker, navigate with j/k, Enter to apply, Esc to cancel

### Implementation

**`ui/theme.go`** — Core theme system:
- `ApplyTheme(name)` sets all `Color*` vars, rebuilds all `Style*` vars, re-renders all glyph strings, and sets the huh theme
- Catppuccin themes map semantic colors to palette roles: Mauve→highlight, Surface0→subtle, Green→green, Yellow→yellow, Red→red, Overlay0→faint
- Non-Catppuccin themes (dracula, charm, base16) use handpicked hex values
- Glyph rendering moved from package init to `initStyles()` so they update on theme change

**`screens/vault.go`** — Theme picker:
- `huh.Select` form with all 7 theme options, centered in the content area
- Footer shows "enter select · esc cancel" while picker is open
- Toast confirms the new theme after selection

**`screens/locked.go`** — huh form themed:
- Unlock/login forms use `ui.HuhTheme` via `.WithTheme()`

**`main.go`** — Flag and env var:
- `--theme` flag with empty default (falls through to catppuccin-mocha)
- `LAZYBW_THEME` env var as fallback

### Tests

- `ApplyTheme("catppuccin-mocha")` — verifies Mocha mauve hex in ColorHighlight
- `ApplyTheme("dracula")` — verifies Dracula purple hex
- Unknown theme falls back to catppuccin-mocha colors
- Glyphs non-empty after theme change
- ThemeNames not empty

Closes #2