### PR TITLE
Simplify keybindings: replace ctrl modifiers with single keys

### DIFF
--- a/.ai/DESIGN.md
+++ b/.ai/DESIGN.md
@@ -60,7 +60,7 @@ simply show longer names and descriptions — no layout mode change needed.
   TOTP       843 291  ▓▓▓▓▓▓▓░░░░░  18s         [t] copy
   URL        console.aws.amazon.com             [o] open
 
-j/k navigate  /  search  c pwd  t totp  u user  ctrl+r  ?  q
+j/k navigate  /  search  c pwd  t totp  u user  r  ?  q
 ```
 
 Key observations:
@@ -157,12 +157,12 @@ Unauthenticated ──── bw login ────▶ Locked
                                       │
                                       ▼
                               ┌─── Vault ───┐
-                              │  List       │◀─── ctrl+r sync
+                              │  List       │◀─── r sync
                               │  Drawer     │
                               │  Filter (/) │
                               └─────────────┘
                                       │
-                              ctrl+l / idle timeout
+                              l / idle timeout
                                       │
                                       ▼
                                    Locked
@@ -238,8 +238,8 @@ The TOTP row is live. Once `bw get totp <id>` resolves:
 | `u` | Copy username |
 | `o` | Open first URL in browser (`xdg-open`) |
 | `/` | Enter filter mode |
-| `ctrl+r` | Sync vault (`bw sync`) |
-| `ctrl+l` | Lock vault immediately |
+| `r` | Sync vault (`bw sync`) |
+| `l` | Lock vault immediately |
 | `?` | Toggle full help |
 | `q` / `ctrl+c` | Lock + quit |
 
@@ -267,7 +267,7 @@ One line, always at the bottom. Left = context or toast; right = account info.
 
 **Normal:**
 ```
-j/k navigate  /  search  c pwd  t totp  u user  ctrl+r sync  ?  q quit
+j/k navigate  /  search  c pwd  t totp  u user  r sync  ?  q quit
 ```
 
 **With toast:**
@@ -300,8 +300,8 @@ bw status
 bw status                        # {status, userEmail, lastSync}
 bw login [email] [pw] --raw      # returns session token
 bw unlock [pw] --raw             # returns session token
-bw lock                          # on quit / ctrl+l / idle timeout
-bw sync                          # ctrl+r
+bw lock                          # on quit / l / idle timeout
+bw sync                          # r
 bw list items                    # full vault JSON
 bw get password [id]             # plaintext password for copy
 bw get totp [id]                 # current TOTP code (live)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A fast, keyboard-driven TUI for [Bitwarden](https://bitwarden.com) built with Go
   TOTP       843 291  ● 18s                     [t] copy
   URL        console.aws.amazon.com             [o] open
 
-j/k navigate  /  search  c pwd  t totp  u user  ctrl+r  ?  q
+j/k navigate  /  search  c pwd  t totp  u user  r  ?  q
 ```
 
 ## Features
@@ -109,8 +109,8 @@ Press `T` in the vault to open the theme picker and switch themes on the fly.
 | `o` | Open URL in browser |
 | `J` / `K` | Scroll note content in drawer |
 | `p` | Open password generator |
-| `Ctrl+r` | Sync vault |
-| `Ctrl+l` | Lock vault |
+| `r` | Sync vault |
+| `l` | Lock vault |
 | `T` | Open theme picker |
 | `?` | Toggle full help |
 | `q` | Lock and quit |

--- a/ui/keymap.go
+++ b/ui/keymap.go
@@ -87,12 +87,12 @@ func DefaultVaultKeyMap() VaultKeyMap {
 			key.WithHelp("K", "scroll drawer ↑"),
 		),
 		Sync: key.NewBinding(
-			key.WithKeys("ctrl+r"),
-			key.WithHelp("ctrl+r", "sync"),
+			key.WithKeys("r"),
+			key.WithHelp("r", "sync"),
 		),
 		Lock: key.NewBinding(
-			key.WithKeys("ctrl+l"),
-			key.WithHelp("ctrl+l", "lock"),
+			key.WithKeys("l"),
+			key.WithHelp("l", "lock"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("?"),


### PR DESCRIPTION
## Summary

Replaces unnecessary `ctrl+` modifier keybindings with simpler single-key alternatives.

| Before | After | Action |
|---|---|---|
| `ctrl+r` | `r` | Sync vault |
| `ctrl+l` | `l` | Lock vault |
| `ctrl+c` | `ctrl+c` (unchanged) | Quit (terminal standard) |

Both `r` and `l` are free in normal mode with no conflicts across filter mode (captures text input in its own handler), generator, or theme picker.

### Files changed

- `ui/keymap.go` — Updated key bindings and help text
- `README.md` — Updated keybinding tables and status bar example
- `.ai/DESIGN.md` — Updated keybinding section, state diagram, CLI reference

Closes #32