### PR TITLE
Render pickers and overlays as popup cards

### DIFF
--- a/screens/vault.go
+++ b/screens/vault.go
@@ -119,6 +119,13 @@ func (m VaultModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showThemePicker {
 			return m.updateThemePicker(msg)
 		}
+		if m.showHelp {
+			if key.Matches(msg, key.NewBinding(key.WithKeys("esc"))) {
+				m.showHelp = false
+				return m, nil
+			}
+			return m, nil
+		}
 		if m.mode == modeFilter {
 			return m.updateFilter(msg)
 		}
@@ -555,22 +562,21 @@ func (m *VaultModel) genArgs() []string {
 	return args
 }
 
-func (m VaultModel) renderGenerator(width, contentHeight int) string {
+func (m VaultModel) renderGeneratorCard() string {
 	var b strings.Builder
 
-	sep := ui.StyleFaint.Render("── Password Generator " + strings.Repeat("─", max(0, width-24)))
-	b.WriteString(sep)
+	b.WriteString(ui.StyleTitle.Render("Password Generator"))
 	b.WriteString("\n\n")
 
 	// Mode indicator.
 	if m.genMode == "password" {
-		b.WriteString("  Mode        ")
+		b.WriteString("Mode        ")
 		b.WriteString(ui.StyleTitle.Render("[Password]"))
 		b.WriteString("  ")
 		b.WriteString(ui.StyleFaint.Render("Passphrase"))
 		b.WriteString("\n")
 	} else {
-		b.WriteString("  Mode        ")
+		b.WriteString("Mode        ")
 		b.WriteString(ui.StyleFaint.Render("Password"))
 		b.WriteString("  ")
 		b.WriteString(ui.StyleTitle.Render("[Passphrase]"))
@@ -579,24 +585,22 @@ func (m VaultModel) renderGenerator(width, contentHeight int) string {
 
 	// Options.
 	if m.genMode == "password" {
-		fmt.Fprintf(&b, "  Length      %d\n", m.genLength)
-		fmt.Fprintf(&b, "  Uppercase   %s   Lowercase  %s   Numbers  %s   Special  %s\n",
+		fmt.Fprintf(&b, "Length      %d\n", m.genLength)
+		fmt.Fprintf(&b, "Uppercase   %s   Lowercase  %s   Numbers  %s   Special  %s\n",
 			checkMark(m.genUppercase), checkMark(m.genLowercase),
 			checkMark(m.genNumbers), checkMark(m.genSpecial))
 	} else {
-		fmt.Fprintf(&b, "  Words       %d         Separator  %s\n", m.genWords, m.genSeparator)
-		fmt.Fprintf(&b, "  Capitalize  %s         Include #  %s\n",
+		fmt.Fprintf(&b, "Words       %d         Separator  %s\n", m.genWords, m.genSeparator)
+		fmt.Fprintf(&b, "Capitalize  %s         Include #  %s\n",
 			checkMark(m.genCapitalize), checkMark(m.genIncludeNum))
 	}
 
 	b.WriteString("\n")
 
 	// Generated output.
-	b.WriteString("  ")
 	b.WriteString(ui.StyleTitle.Render(m.genPassword))
-	b.WriteString("\n")
 
-	return ui.CenterInArea(b.String(), width, contentHeight)
+	return b.String()
 }
 
 func checkMark(v bool) string {
@@ -608,13 +612,23 @@ func checkMark(v bool) string {
 
 // ViewContent renders the vault content for the root frame.
 func (m VaultModel) ViewContent(width, contentHeight int) string {
+	bg := m.renderVaultContent(width, contentHeight)
+
 	if m.showGenerator {
-		return m.renderGenerator(width, contentHeight)
+		return ui.RenderOverlay(bg, m.renderGeneratorCard(), width, contentHeight)
 	}
 	if m.showThemePicker && m.themeForm != nil {
-		return ui.CenterInArea(m.themeForm.View(), width, contentHeight)
+		return ui.RenderOverlay(bg, m.themeForm.View(), width, contentHeight)
+	}
+	if m.showHelp {
+		return ui.RenderOverlay(bg, m.help.View(m.keymap), width, contentHeight)
 	}
 
+	return bg
+}
+
+// renderVaultContent renders the normal vault layout (filter + list + drawer).
+func (m VaultModel) renderVaultContent(width, contentHeight int) string {
 	drawer := ui.RenderDrawer(ui.DrawerProps{
 		Item:         m.selectedItem(),
 		TOTPCode:     m.totpCode,
@@ -626,9 +640,6 @@ func (m VaultModel) ViewContent(width, contentHeight int) string {
 	listHeight := contentHeight - ui.DrawerHeight
 	if m.mode == modeFilter {
 		listHeight--
-	}
-	if m.showHelp {
-		listHeight -= 5
 	}
 	if listHeight < 1 {
 		listHeight = 1
@@ -642,9 +653,6 @@ func (m VaultModel) ViewContent(width, contentHeight int) string {
 		sections = append(sections, filterBar)
 	}
 	sections = append(sections, listView, drawer)
-	if m.showHelp {
-		sections = append(sections, m.help.View(m.keymap))
-	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, sections...)
 }
@@ -657,6 +665,10 @@ func (m VaultModel) FooterContent() (hints, status string) {
 	}
 	if m.showThemePicker {
 		hints = "enter select · esc cancel"
+		return hints, ""
+	}
+	if m.showHelp {
+		hints = "esc close"
 		return hints, ""
 	}
 	if m.mode == modeFilter {

--- a/ui/overlay.go
+++ b/ui/overlay.go
@@ -1,0 +1,79 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// RenderOverlay composites a foreground popup card centered over a
+// dimmed background using lipgloss v2's Compositor/Layer API.
+func RenderOverlay(bg, fg string, width, height int) string {
+	// Pad background to fill the full area so the compositor
+	// canvas is correctly sized.
+	bg = padToArea(bg, width, height)
+
+	// Dim the background to visually separate it from the overlay.
+	dimmed := lipgloss.NewStyle().Faint(true).Render(bg)
+
+	// Wrap foreground in a bordered card with padding.
+	card := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorSubtle).
+		Padding(1, 2).
+		Render(fg)
+
+	cardW := lipgloss.Width(card)
+	cardH := lipgloss.Height(card)
+
+	// Clamp card to available area.
+	if cardW > width {
+		cardW = width
+	}
+	if cardH > height {
+		cardH = height
+	}
+
+	x := (width - cardW) / 2
+	y := (height - cardH) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	bgLayer := lipgloss.NewLayer(dimmed)
+	fgLayer := lipgloss.NewLayer(card).X(x).Y(y).Z(1)
+
+	return lipgloss.NewCompositor(bgLayer, fgLayer).Render()
+}
+
+// padToArea ensures content fills exactly width x height by padding
+// lines to width and adding empty lines to reach height.
+func padToArea(content string, width, height int) string {
+	lines := strings.Split(content, "\n")
+
+	// Remove trailing empty line from Split if content ends with \n.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	var b strings.Builder
+	for i := 0; i < height; i++ {
+		if i < len(lines) {
+			line := lines[i]
+			lineW := lipgloss.Width(line)
+			b.WriteString(line)
+			if lineW < width {
+				b.WriteString(strings.Repeat(" ", width-lineW))
+			}
+		} else {
+			b.WriteString(strings.Repeat(" ", width))
+		}
+		if i < height-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

- Add shared `ui.RenderOverlay()` using lipgloss v2's native `Compositor`/`Layer` API for cell-level compositing
- Theme picker, password generator, and help menu now render as bordered popup cards centered over a dimmed vault background instead of replacing the entire content area
- Help overlay closes with ESC (previously only toggled with `?`)

Closes #36

## Test plan

- [x] Open theme picker (`T`) — vault list visible behind bordered popup
- [x] Open password generator (`p`) — vault list visible behind bordered popup
- [x] Open help (`?`) — vault list visible behind bordered popup
- [x] ESC closes all three overlays
- [x] Verify overlays center correctly at different terminal sizes
- [x] Verify background is dimmed when overlay is active