### PR TITLE
Harden sensitive data handling in memory and subprocesses

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Considerations
+
+lazybw is a terminal UI wrapper around the Bitwarden CLI (`bw`). It
+necessarily holds decrypted vault data in memory while the session is
+unlocked. This document describes the security design, mitigations, and
+accepted risks.
+
+## Secret lifecycle
+
+When the vault is unlocked, decrypted items (passwords, TOTP seeds, card
+numbers, SSNs, SSH private keys) are cached in the `VaultModel`. On lock
+(manual, idle timeout, or quit):
+
+1. **Byte-slice secrets are zeroed in-place.** The decoded TOTP secret
+   (`totp.Params.Secret`) is overwritten with zeros before the reference
+   is dropped. This genuinely scrubs the key material from memory.
+
+2. **String-field secrets have references dropped.** Go strings are
+   immutable — the backing bytes cannot be zeroed from safe Go code. We
+   set each sensitive string field to `""`, which releases the reference
+   and allows the garbage collector to reclaim the underlying memory. The
+   old bytes may persist in the heap until the GC runs.
+
+3. **The session token is cleared.** `State.Lock()` sets `Token` to `""`
+   and resets `LastSync`. A `bw lock` command is also issued to the CLI
+   to lock the server-side session.
+
+4. **Email is retained.** The user's email is kept after lock for display
+   on the unlock screen. It is not considered secret — `bw status`
+   returns it without authentication.
+
+## Master password handling
+
+The master password is passed to the `bw` CLI via `--passwordenv
+BW_PASSWORD`, which reads it from a process-local environment variable.
+This avoids exposing the password in `ps`, `top`, or
+`/proc/PID/cmdline`. The environment variable is only readable by the
+process owner (or root) via `/proc/PID/environ`.
+
+Minimum `bw` CLI version required: **1.21.0** (when `--passwordenv` was
+introduced).
+
+## Session token
+
+The `BW_SESSION` token is passed to child `bw` processes via the
+`BW_SESSION` environment variable. This is the standard mechanism used by
+the Bitwarden CLI itself.
+
+## Clipboard
+
+Clipboard operations use OSC 52 terminal escape sequences — no
+intermediate clipboard manager processes are spawned. Copied secrets are
+automatically cleared after 60 seconds.
+
+## Memory locking (mlock)
+
+lazybw does **not** call `mlock` or `mlockall`. Go's runtime freely
+allocates, moves, and copies memory (GC compaction, goroutine stack
+growth/shrinking). Calling `mlock` on specific buffers would not prevent
+the runtime from placing copies of sensitive data in unlocked pages.
+Libraries like `memguard` add complexity without reliable guarantees in a
+standard Go program.
+
+**Accepted risk:** Under memory pressure, pages containing secret data
+could be swapped to disk. This is a known limitation shared by most Go
+applications that handle secrets.
+
+## Subprocess environment
+
+Child `bw` processes inherit the parent's full environment via
+`os.Environ()`, with `BW_SESSION` (and `BW_PASSWORD` for login/unlock)
+appended. This is standard practice and ensures the child process has
+access to necessary system configuration (locale, PATH, etc.).
+
+## Out of scope
+
+These areas were reviewed and found to be already well-handled:
+
+- **Clipboard**: OSC 52 with 60-second auto-clear
+- **Debug logging**: No secrets logged; log files use 0600 permissions
+- **Shell injection**: All subprocess arguments are passed as
+  `exec.Command` argv, never through a shell

--- a/bwcmd/exec.go
+++ b/bwcmd/exec.go
@@ -78,6 +78,33 @@ func execBw(sessionToken string, args ...string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// execBwWithPassword is like execBw but also sets BW_PASSWORD in the
+// child process environment. This keeps the master password out of the
+// argument list, hiding it from ps/top and /proc/PID/cmdline.
+func execBwWithPassword(sessionToken, password string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bw", args...) //nolint:gosec // args are constructed internally, not from user input
+	cmd.Env = append(os.Environ(),
+		"BW_SESSION="+sessionToken,
+		"BW_PASSWORD="+password,
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg == "" {
+			errMsg = err.Error()
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+	return stdout.Bytes(), nil
+}
+
 // CheckStatus runs `bw status` and returns a StatusResult.
 func CheckStatus() tea.Cmd {
 	return func() tea.Msg {
@@ -108,10 +135,13 @@ func FetchItems(token string) tea.Cmd {
 	}
 }
 
-// Unlock runs `bw unlock [password] --raw` and returns an UnlockResult.
+// Unlock runs `bw unlock --passwordenv BW_PASSWORD --raw` and returns
+// an UnlockResult. The password is passed via a process-local environment
+// variable instead of a CLI argument to avoid exposing it in
+// /proc/PID/cmdline.
 func Unlock(password string) tea.Cmd {
 	return func() tea.Msg {
-		out, err := execBw("", "unlock", password, "--raw")
+		out, err := execBwWithPassword("", password, "unlock", "--passwordenv", "BW_PASSWORD", "--raw")
 		if err != nil {
 			return UnlockResult{Err: err}
 		}
@@ -119,10 +149,12 @@ func Unlock(password string) tea.Cmd {
 	}
 }
 
-// Login runs `bw login [email] [password] --raw` and returns an UnlockResult.
+// LoginUser runs `bw login [email] --passwordenv BW_PASSWORD --raw` and
+// returns an UnlockResult. The password is passed via a process-local
+// environment variable instead of a CLI argument.
 func LoginUser(email, password string) tea.Cmd {
 	return func() tea.Msg {
-		out, err := execBw("", "login", email, password, "--raw")
+		out, err := execBwWithPassword("", password, "login", email, "--passwordenv", "BW_PASSWORD", "--raw")
 		if err != nil {
 			return UnlockResult{Err: err}
 		}

--- a/model.go
+++ b/model.go
@@ -139,6 +139,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.sess.Token != "" {
 			m.state = stateQuitting
 			token := m.sess.Token
+			m.vault.Clear()
 			m.sess.Lock()
 			return m, tea.Batch(m.spinner.Tick, bwcmd.Lock(token))
 		}
@@ -152,6 +153,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.spinner.Spinner = ui.SpinnerLock
 		if m.sess.Token != "" {
 			token := m.sess.Token
+			m.vault.Clear()
 			m.sess.Lock()
 			return m, tea.Batch(m.spinner.Tick, bwcmd.Lock(token))
 		}
@@ -172,6 +174,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case idleCheckMsg:
 		if m.state == stateVault && m.sess.IsIdle() {
 			token := m.sess.Token
+			m.vault.Clear()
 			m.sess.Lock()
 			m.lockFor = intentLock
 			m.state = stateLocked
@@ -188,6 +191,7 @@ func (m RootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.spinner.Spinner = ui.SpinnerLock
 			if m.sess.Token != "" {
 				token := m.sess.Token
+				m.vault.Clear()
 				m.sess.Lock()
 				return m, tea.Batch(m.spinner.Tick, bwcmd.Lock(token))
 			}

--- a/screens/locked.go
+++ b/screens/locked.go
@@ -122,6 +122,7 @@ func (m LockedModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = lockedUnlocking
 		m.err = nil
 		pw := *m.password
+		*m.password = "" // drop the form's reference to the password
 		email := *m.email
 		if m.isLogin {
 			return m, tea.Batch(m.spinner.Tick, bwcmd.LoginUser(email, pw))

--- a/screens/vault.go
+++ b/screens/vault.go
@@ -14,6 +14,7 @@ import (
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/juthrbog/lazybw/bwcmd"
+	"github.com/juthrbog/lazybw/secutil"
 	"github.com/juthrbog/lazybw/session"
 	"github.com/juthrbog/lazybw/totp"
 	"github.com/juthrbog/lazybw/ui"
@@ -157,6 +158,20 @@ func NewVaultModel(items []bwcmd.Item, sess *session.State, width, height int) V
 	}
 
 	return m
+}
+
+// Clear scrubs sensitive data from the vault model. It zeros []byte
+// secrets in-place and drops references to sensitive string fields so
+// the GC can collect the underlying memory sooner.
+func (m *VaultModel) Clear() {
+	secutil.ZeroItems(m.rawItems)
+	m.rawItems = nil
+	if m.totpParams != nil {
+		m.totpParams.Clear()
+		m.totpParams = nil
+	}
+	m.totpCode = ""
+	m.genPassword = ""
 }
 
 func (m VaultModel) Init() tea.Cmd {
@@ -431,7 +446,10 @@ func (m VaultModel) handleActionKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, b
 
 func (m *VaultModel) onCursorChange() tea.Cmd {
 	m.drawerScroll = 0
-	m.totpParams = nil
+	if m.totpParams != nil {
+		m.totpParams.Clear()
+		m.totpParams = nil
+	}
 	m.totpCode = ""
 
 	item := m.selectedItem()

--- a/secutil/zero.go
+++ b/secutil/zero.go
@@ -1,0 +1,43 @@
+package secutil
+
+import "github.com/juthrbog/lazybw/bwcmd"
+
+// ZeroBytes overwrites every element in b with zero. This is effective
+// for []byte-backed secrets (e.g. decoded TOTP keys) because Go allows
+// in-place mutation of byte slices.
+func ZeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// ZeroItem drops references to sensitive string fields on a vault item.
+// Go strings are immutable, so we cannot zero their backing memory — we
+// can only release references so the GC can collect the underlying data
+// sooner and prevent accidental reads of stale secrets.
+func ZeroItem(item *bwcmd.Item) {
+	item.Notes = ""
+	if item.Login != nil {
+		item.Login.Password = ""
+		item.Login.Totp = ""
+	}
+	if item.Card != nil {
+		item.Card.Number = ""
+		item.Card.Code = ""
+	}
+	if item.Identity != nil {
+		item.Identity.SSN = ""
+		item.Identity.PassportNumber = ""
+		item.Identity.LicenseNumber = ""
+	}
+	if item.SSHKey != nil {
+		item.SSHKey.PrivateKey = ""
+	}
+}
+
+// ZeroItems calls ZeroItem on every element in the slice.
+func ZeroItems(items []bwcmd.Item) {
+	for i := range items {
+		ZeroItem(&items[i])
+	}
+}

--- a/secutil/zero_test.go
+++ b/secutil/zero_test.go
@@ -1,0 +1,119 @@
+package secutil
+
+import (
+	"testing"
+
+	"github.com/juthrbog/lazybw/bwcmd"
+)
+
+func TestZeroBytes(t *testing.T) {
+	b := []byte{0x41, 0x42, 0x43}
+	ZeroBytes(b)
+	for i, v := range b {
+		if v != 0 {
+			t.Errorf("b[%d] = %d, want 0", i, v)
+		}
+	}
+}
+
+func TestZeroBytesNil(t *testing.T) {
+	ZeroBytes(nil) // should not panic
+}
+
+func TestZeroItem(t *testing.T) {
+	item := bwcmd.Item{
+		Notes: "secret note",
+		Login: &bwcmd.Login{
+			Username: "user",
+			Password: "hunter2",
+			Totp:     "JBSWY3DPEHPK3PXP",
+		},
+		Card: &bwcmd.Card{
+			CardholderName: "John",
+			Number:         "4111111111111111",
+			Code:           "123",
+		},
+		Identity: &bwcmd.Identity{
+			FirstName:      "John",
+			SSN:            "123-45-6789",
+			PassportNumber: "AB1234567",
+			LicenseNumber:  "DL999",
+		},
+		SSHKey: &bwcmd.SSHKey{
+			PrivateKey:     "-----BEGIN OPENSSH PRIVATE KEY-----",
+			PublicKey:      "ssh-ed25519 AAAA...",
+			KeyFingerprint: "SHA256:abc",
+		},
+	}
+
+	ZeroItem(&item)
+
+	// Sensitive fields should be cleared.
+	if item.Notes != "" {
+		t.Error("Notes not cleared")
+	}
+	if item.Login.Password != "" {
+		t.Error("Login.Password not cleared")
+	}
+	if item.Login.Totp != "" {
+		t.Error("Login.Totp not cleared")
+	}
+	if item.Card.Number != "" {
+		t.Error("Card.Number not cleared")
+	}
+	if item.Card.Code != "" {
+		t.Error("Card.Code not cleared")
+	}
+	if item.Identity.SSN != "" {
+		t.Error("Identity.SSN not cleared")
+	}
+	if item.Identity.PassportNumber != "" {
+		t.Error("Identity.PassportNumber not cleared")
+	}
+	if item.Identity.LicenseNumber != "" {
+		t.Error("Identity.LicenseNumber not cleared")
+	}
+	if item.SSHKey.PrivateKey != "" {
+		t.Error("SSHKey.PrivateKey not cleared")
+	}
+
+	// Non-sensitive fields should be preserved.
+	if item.Login.Username != "user" {
+		t.Error("Login.Username should be preserved")
+	}
+	if item.Card.CardholderName != "John" {
+		t.Error("Card.CardholderName should be preserved")
+	}
+	if item.Identity.FirstName != "John" {
+		t.Error("Identity.FirstName should be preserved")
+	}
+	if item.SSHKey.PublicKey != "ssh-ed25519 AAAA..." {
+		t.Error("SSHKey.PublicKey should be preserved")
+	}
+}
+
+func TestZeroItemNilSubstructs(t *testing.T) {
+	item := bwcmd.Item{Notes: "note"}
+	ZeroItem(&item) // should not panic with nil Login/Card/Identity/SSHKey
+	if item.Notes != "" {
+		t.Error("Notes not cleared")
+	}
+}
+
+func TestZeroItems(t *testing.T) {
+	items := []bwcmd.Item{
+		{Login: &bwcmd.Login{Password: "pw1"}},
+		{Login: &bwcmd.Login{Password: "pw2"}},
+	}
+	ZeroItems(items)
+	for i, item := range items {
+		if item.Login.Password != "" {
+			t.Errorf("items[%d].Login.Password not cleared", i)
+		}
+	}
+}
+
+func TestZeroItemsEmpty(t *testing.T) {
+	ZeroItems(nil)          // should not panic
+	ZeroItems([]bwcmd.Item{}) // should not panic
+}

--- a/session/manager.go
+++ b/session/manager.go
@@ -18,8 +18,10 @@ func (s *State) IsLocked() bool {
 }
 
 // Lock clears the token and any other sensitive in-memory state.
+// Email is intentionally retained for the unlock screen display.
 func (s *State) Lock() {
 	s.Token = ""
+	s.LastSync = time.Time{}
 }
 
 // SetToken stores the session token obtained from `bw unlock`.

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -24,13 +24,24 @@ func TestSetToken(t *testing.T) {
 }
 
 func TestLock(t *testing.T) {
-	s := State{Token: "test-token"}
+	s := State{
+		Token:    "test-token",
+		Email:    "user@example.com",
+		LastSync: time.Now(),
+	}
 	s.Lock()
 	if !s.IsLocked() {
 		t.Error("should be locked after Lock()")
 	}
 	if s.Token != "" {
 		t.Errorf("Token = %q, want empty", s.Token)
+	}
+	if !s.LastSync.IsZero() {
+		t.Error("LastSync should be zero after Lock()")
+	}
+	// Email is intentionally preserved for the unlock screen.
+	if s.Email != "user@example.com" {
+		t.Errorf("Email = %q, want preserved", s.Email)
 	}
 }
 

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -54,6 +54,15 @@ func Parse(raw string) (Params, error) {
 	return p, nil
 }
 
+// Clear zeros the secret bytes in-place and nils the slice, preventing
+// the decoded key material from lingering in memory after use.
+func (p *Params) Clear() {
+	for i := range p.Secret {
+		p.Secret[i] = 0
+	}
+	p.Secret = nil
+}
+
 // Code returns the TOTP code for the current time.
 func Code(p Params) string {
 	return CodeAt(p, time.Now())

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -152,6 +152,31 @@ func TestCodeAt_Deterministic(t *testing.T) {
 	}
 }
 
+func TestParams_Clear(t *testing.T) {
+	p, err := Parse("JBSWY3DPEHPK3PXP")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Secret) == 0 {
+		t.Fatal("Secret should be non-empty before Clear")
+	}
+
+	// Keep a reference to the original backing array so we can verify
+	// the bytes were actually zeroed in-place.
+	orig := p.Secret
+
+	p.Clear()
+
+	if p.Secret != nil {
+		t.Error("Secret should be nil after Clear")
+	}
+	for i, b := range orig {
+		if b != 0 {
+			t.Errorf("orig[%d] = %d, want 0 — backing array not zeroed", i, b)
+		}
+	}
+}
+
 func TestSecsLeft(t *testing.T) {
 	s := SecsLeft(30)
 	if s < 1 || s > 30 {


### PR DESCRIPTION
## Summary

- **Zero secrets on lock**: Add `VaultModel.Clear()` that scrubs all sensitive vault data (passwords, TOTP seeds, card numbers, SSNs, SSH private keys) on every lock path — manual, quit, idle timeout, and ctrl+c
- **Hide master password from procfs**: Switch `bw unlock`/`bw login` from passing the password as a CLI argument (visible in `/proc/PID/cmdline`) to `--passwordenv BW_PASSWORD` (only readable by process owner)
- **Zero TOTP secret bytes in-place**: Add `totp.Params.Clear()` that overwrites the decoded `[]byte` key material with zeros before dropping the reference — called on both item change and lock
- **Complete lock cleanup**: `State.Lock()` now also clears `LastSync`; password form widget is cleared after reading

New `secutil` package provides `ZeroBytes`/`ZeroItem`/`ZeroItems` helpers. New `SECURITY.md` documents all design decisions and accepted risks (Go string immutability, no mlock, email retention).

Closes #73

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./...` — all tests pass (including new secutil, totp, session tests)
- [x] `golangci-lint run --enable gosec` — no findings
- [x] Manual: unlock vault, browse items, lock — verify unlock still works with `--passwordenv`
- [x] Manual: during unlock, run `ps aux | grep bw` — confirm password is not in argv